### PR TITLE
modify response class to facilitate extensibility

### DIFF
--- a/Saml.cs
+++ b/Saml.cs
@@ -85,11 +85,11 @@ namespace Saml
 		}
 	}
 
-	public class Response
+	public partial class Response
 	{
-		private XmlDocument _xmlDoc;
-		private Certificate _certificate;
-		private XmlNamespaceManager _xmlNameSpaceManager; //we need this one to run our XPath queries on the SAML XML
+		protected XmlDocument _xmlDoc;
+		protected readonly Certificate _certificate;
+		protected XmlNamespaceManager _xmlNameSpaceManager; //we need this one to run our XPath queries on the SAML XML
 
 		public string Xml { get { return _xmlDoc.OuterXml; } }
 


### PR DESCRIPTION
Changed the Response class so that it can be more extensible when it comes to adding new properties; you can derive from it or create a partial class. There is probably a better way to do this, perhaps using a dictionary of the properties brought back in response but this at least will save me the hassle of editing your nuget class.