### PR TITLE
Minor performance improvements

### DIFF
--- a/AspNetSaml/AspNetSaml.csproj
+++ b/AspNetSaml/AspNetSaml.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/AspNetSaml/AspNetSaml.csproj
+++ b/AspNetSaml/AspNetSaml.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -311,7 +311,7 @@ namespace Saml
 					streamInput.CopyTo(deflate);
 				}
 				
-				return Convert.ToBase64String(compressed.GetBuffer(), 0, (int)compressed.Length);
+				return Convert.ToBase64String(compressed.GetBuffer(), 0, (int)compressed.Length, Base64FormattingOptions.None);
 			}
 		}
 

--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -13,8 +13,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.IO.Compression;
 using System.Text;
-using System.Runtime;
-using System.Text.Encodings.Web;
 
 namespace Saml
 {
@@ -325,11 +323,11 @@ namespace Saml
 		{
 			var queryStringSeparator = samlEndpoint.Contains('?') ? '&' : '?';
 
-			var url = samlEndpoint + queryStringSeparator + "SAMLRequest=" + UrlEncoder.Default.Encode(GetRequest());
+			var url = samlEndpoint + queryStringSeparator + "SAMLRequest=" + Uri.EscapeDataString(GetRequest());
 
 			if (!string.IsNullOrEmpty(relayState)) 
 			{
-				url += "&RelayState=" + UrlEncoder.Default.Encode(relayState);
+				url += "&RelayState=" + Uri.EscapeDataString(relayState);
 			}
 
 			return url;


### PR DESCRIPTION
Made some changes that improve performance a small amount, but cut allocations by more than half. 
Also changed the accessors and added `readonly` to help enforce .NET design guidelines.

Benchmarks between the current version and the updated version, using `BenchmarkDotNet`:
```
| Method        | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| GetRequestOld | 5.334 us | 0.0151 us | 0.0212 us | 0.5493 | 0.0153 |  26.97 KB |
| GetRequestNew | 4.998 us | 0.0252 us | 0.0377 us | 0.2365 |      - |  11.62 KB |
```