### PR TITLE
Expose more useful SAML fields

### DIFF
--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -235,6 +235,12 @@ namespace Saml
 			XmlNodeList nodes = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:AttributeStatement/saml:Attribute[@Name='" + attr + "']/saml:AttributeValue", _xmlNameSpaceManager);
 			return nodes?.Cast<XmlNode>().Select(x => x.InnerText).ToList();
 		}
+
+		public List<string> GetIntendedAudiences()
+		{
+            XmlNodeList nodes = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:Conditions/saml:AudienceRestriction/saml:Audience", _xmlNameSpaceManager);
+            return nodes?.Cast<XmlNode>().Select(x => x.InnerText).ToList();
+        }
 	}
 
 	/// <summary>

--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -241,6 +241,20 @@ namespace Saml
             XmlNodeList nodes = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:Conditions/saml:AudienceRestriction/saml:Audience", _xmlNameSpaceManager);
             return nodes?.Cast<XmlNode>().Select(x => x.InnerText).ToList();
         }
+
+        /// <summary>
+        /// Some IdPs set the SessionNotOnOrAfter attribute to inform the SP how long they expect the local session with the SP to be valid for.
+        /// </summary>
+        public DateTime? GetExpectedSessionExpiry()
+		{
+            XmlNode node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:AuthnStatement", _xmlNameSpaceManager);
+            if (node != null && node.Attributes["SessionNotOnOrAfter"] != null) {
+                if (DateTime.TryParse(node.Attributes["SessionNotOnOrAfter"].Value, out var expirationDate)) {
+					return expirationDate;
+				}
+            }
+            return null;
+        }
 	}
 
 	/// <summary>

--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -66,6 +66,18 @@ namespace Saml
 			LoadXml(Encoding.UTF8.GetString(Convert.FromBase64String(response)));
 		}
 
+		private XmlElement GetAssertionElement()
+		{
+			return _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion", _xmlNameSpaceManager) as XmlElement;
+        }
+
+		public string GetAssertionID()
+		{
+			var assertionElement = GetAssertionElement();
+
+			return assertionElement?.GetAttribute("ID");
+        }
+
 		//an XML signature can "cover" not the whole document, but only a part of it
 		//.NET's built in "CheckSignature" does not cover this case, it will validate to true.
 		//We should check the signature reference, so it "references" the id of the root document element! If not - it's a hack
@@ -83,7 +95,7 @@ namespace Saml
 				return true;
 			else //sometimes its not the "root" doc-element that is being signed, but the "assertion" element
 			{
-				var assertionNode = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion", _xmlNameSpaceManager) as XmlElement;
+				var assertionNode = GetAssertionElement();
 				if (assertionNode != idElement)
 					return false;
 			}

--- a/AspNetSaml/Saml.cs
+++ b/AspNetSaml/Saml.cs
@@ -119,15 +119,20 @@ namespace Saml
 			return ValidateSignatureReference(signedXml) && signedXml.CheckSignature(_certificate, true) && !IsExpired();
 		}
 
+		public virtual DateTime GetExpirationDate()
+		{
+            DateTime expirationDate = DateTime.MaxValue;
+            XmlNode node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager);
+            if (node != null && node.Attributes["NotOnOrAfter"] != null) {
+                DateTime.TryParse(node.Attributes["NotOnOrAfter"].Value, out expirationDate);
+            }
+			return expirationDate;
+        }
+
 		protected virtual bool IsExpired()
 		{
-			DateTime expirationDate = DateTime.MaxValue;
-			XmlNode node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager);
-			if (node != null && node.Attributes["NotOnOrAfter"] != null)
-			{
-				DateTime.TryParse(node.Attributes["NotOnOrAfter"].Value, out expirationDate);
-			}
-			return (CurrentTime ?? DateTime.UtcNow) > expirationDate.ToUniversalTime();
+			var expirationDate = GetExpirationDate();
+            return (CurrentTime ?? DateTime.UtcNow) > expirationDate.ToUniversalTime();
 		}
 
 		public DateTime? CurrentTime { get; set; } = null; //mostly for unit-testing. STUPID I KNOW, will fix later
@@ -266,12 +271,19 @@ namespace Saml
 			return node?.InnerText;
 		}
 
-		/// <summary>
-		/// Checks the validity of the SAML IdP-initiated LogoutRequest (validate signature).
-		/// This class relies on the base IsValid() method but overrides IsExpired() to always return false,
-		/// effectively bypassing the expiration check which is not relevant for LogoutRequests.
-		/// </summary>
-		protected override bool IsExpired()
+		public override DateTime GetExpirationDate()
+		{
+            // LogoutRequests don't have the standard expiration elements.
+            // Return DateTime.MaxValue to indicate no expiration.
+            return DateTime.MaxValue;
+        }
+
+        /// <summary>
+        /// Checks the validity of the SAML IdP-initiated LogoutRequest (validate signature).
+        /// This class relies on the base IsValid() method but overrides IsExpired() to always return false,
+        /// effectively bypassing the expiration check which is not relevant for LogoutRequests.
+        /// </summary>
+        protected override bool IsExpired()
 		{
 			// LogoutRequests don't have the standard expiration elements.
 			// Return false to ensure the base IsValid() check doesn't fail due to expiration.


### PR DESCRIPTION
This PR exposes the following fields/attributes:

- The `ID` attribute of the SAML Assertion
- The expiration date of the SAML Assertion. Taken from the `NotOnOrAfter` attribute of the SubjectConfirmationData
    - This was already looked up to check for `IsValid` but this PR exposes it to callers.
- The list of `Audience` values from the SAML AudienceRestriction
- The `SessionNotOnOrAfter` attribute from the SAML AuthnStatement

The ID and the expiration date of the SAML Assertion are useful in detecting replay attacks. The ID uniquely identifies individual Assertion responses, so the application can keep track of ones it has seen before. The expiration date determines how long the Assertion the is valid for and therefore how long the application needs to keep track of it for to detect replays.

The Audience values are useful for validating that the Assertion is actually intended for the consuming application, this can also be used to match the correct customer in a multi tenant setup using IdP initiated flow.

The `SessionNotOnOrAfter` attribute is an optional attribute that an IdP can set as a way to tell the consuming application how long it should create a local session for.

